### PR TITLE
Frame-perfect sponsor skips

### DIFF
--- a/youtube_sponsorblock.js
+++ b/youtube_sponsorblock.js
@@ -1,51 +1,51 @@
 // ==UserScript==
-// @name		 Sponsorblock
-// @version	  1.1.0
+// @name         Sponsorblock
+// @version      1.1.0
 // @description  Skip sponsor segments automatically
-// @author	   afreakk
-// @author 		 vongaisberg
-// @match		*://*.youtube.com/*
-// @exclude	  *://*.youtube.com/subscribe_embed?*
+// @author       afreakk
+// @author          vongaisberg
+// @match        *://*.youtube.com/*
+// @exclude      *://*.youtube.com/subscribe_embed?*
 // ==/UserScript==
 const delay = 1000;
 
 const tryFetchSkipSegments = (videoID) =>
 
-	fetch(`https://sponsor.ajay.app/api/skipSegments?videoID=${videoID}`)
-		.then((r) => r.json())
-		.then((rJson) =>
-			rJson.filter((a) => a.actionType === 'skip').map((a) => a.segment)
-		)
-		.catch(
-			(e) =>
-				console.log(
-					`Sponsorblock: failed fetching skipSegments for ${videoID}, reason: ${e}`
-				) || []
-		);
+    fetch(`https://sponsor.ajay.app/api/skipSegments?videoID=${videoID}`)
+        .then((r) => r.json())
+        .then((rJson) =>
+            rJson.filter((a) => a.actionType === 'skip').map((a) => a.segment)
+        )
+        .catch(
+            (e) =>
+                console.log(
+                    `Sponsorblock: failed fetching skipSegments for ${videoID}, reason: ${e}`
+                ) || []
+        );
 
 const skipSegments = async () => {
-	const videoID = new URL(document.location).searchParams.get('v');
-	if (!videoID) {
-		return;
-	}
-	const key = `segmentsToSkip-${videoID}`;
-	window[key] = window[key] || (await tryFetchSkipSegments(videoID));
-	for (const v of document.querySelectorAll('video')) {
-		if (Number.isNaN(v.duration)) continue;
-		for (const [start, end] of window[key]) {
-			if (v.currentTime < end && v.currentTime >= start) {
-				console.log(`Sponsorblock: skipped video @${v.currentTime} from ${start} to ${end}`);
-				v.currentTime = end;
-				return
-			}
-			const timeToSponsor = (start - v.currentTime) / v.playbackRate;
-			if (v.currentTime < start && timeToSponsor < (delay / 1000)) {
-				console.log(`Sponsorblock: Almost at sponsor segment, sleep for ${timeToSponsor * 1000}ms`);
-				setTimeout(skipSegments, timeToSponsor * 1000);
-			}
-		}
-	}
+    const videoID = new URL(document.location).searchParams.get('v');
+    if (!videoID) {
+        return;
+    }
+    const key = `segmentsToSkip-${videoID}`;
+    window[key] = window[key] || (await tryFetchSkipSegments(videoID));
+    for (const v of document.querySelectorAll('video')) {
+        if (Number.isNaN(v.duration)) continue;
+        for (const [start, end] of window[key]) {
+            if (v.currentTime < end && v.currentTime >= start) {
+                console.log(`Sponsorblock: skipped video @${v.currentTime} from ${start} to ${end}`);
+                v.currentTime = end;
+                return
+            }
+            const timeToSponsor = (start - v.currentTime) / v.playbackRate;
+            if (v.currentTime < start && timeToSponsor < (delay / 1000)) {
+                console.log(`Sponsorblock: Almost at sponsor segment, sleep for ${timeToSponsor * 1000}ms`);
+                setTimeout(skipSegments, timeToSponsor * 1000);
+            }
+        }
+    }
 };
 if (!window.skipSegmentsIntervalID) {
-	window.skipSegmentsIntervalID = setInterval(skipSegments, delay);
+    window.skipSegmentsIntervalID = setInterval(skipSegments, delay);
 }

--- a/youtube_sponsorblock.js
+++ b/youtube_sponsorblock.js
@@ -1,12 +1,16 @@
 // ==UserScript==
 // @name         Sponsorblock
-// @version      1.0.0
+// @version      1.1.0
 // @description  Skip sponsor segments automatically
 // @author       afreakk
+// @author 	     vongaisberg
 // @match        *://*.youtube.com/*
 // @exclude      *://*.youtube.com/subscribe_embed?*
 // ==/UserScript==
+const delay = 1000;
+
 const tryFetchSkipSegments = (videoID) =>
+
     fetch(`https://sponsor.ajay.app/api/skipSegments?videoID=${videoID}`)
         .then((r) => r.json())
         .then((rJson) =>
@@ -29,13 +33,19 @@ const skipSegments = async () => {
     for (const v of document.querySelectorAll('video')) {
         if (Number.isNaN(v.duration)) continue;
         for (const [start, end] of window[key]) {
-            if (v.currentTime < end && v.currentTime > start) {
+            if (v.currentTime < end && v.currentTime >= start) {
+                console.log(`Sponsorblock: skipped video @${v.currentTime} from ${start} to ${end}`);
                 v.currentTime = end;
-                return console.log(`Sponsorblock: skipped video to ${end}`);
+		    return
             }
+		const timeToSponsor = (start - v.currentTime) / v.playbackRate;
+		if (v.currentTime < start && timeToSponsor < (delay/1000)) {
+			console.log(`Sponsorblock: Almost at sponsor segment, sleep for ${timeToSponsor*1000}ms`);
+			setTimeout(skipSegments, timeToSponsor * 1000);
+		}
         }
     }
 };
 if (!window.skipSegmentsIntervalID) {
-    window.skipSegmentsIntervalID = setInterval(skipSegments, 1000);
+    window.skipSegmentsIntervalID = setInterval(skipSegments, delay);
 }

--- a/youtube_sponsorblock.js
+++ b/youtube_sponsorblock.js
@@ -1,51 +1,51 @@
 // ==UserScript==
-// @name         Sponsorblock
-// @version      1.1.0
+// @name		 Sponsorblock
+// @version	  1.1.0
 // @description  Skip sponsor segments automatically
-// @author       afreakk
-// @author 	     vongaisberg
-// @match        *://*.youtube.com/*
-// @exclude      *://*.youtube.com/subscribe_embed?*
+// @author	   afreakk
+// @author 		 vongaisberg
+// @match		*://*.youtube.com/*
+// @exclude	  *://*.youtube.com/subscribe_embed?*
 // ==/UserScript==
 const delay = 1000;
 
 const tryFetchSkipSegments = (videoID) =>
 
-    fetch(`https://sponsor.ajay.app/api/skipSegments?videoID=${videoID}`)
-        .then((r) => r.json())
-        .then((rJson) =>
-            rJson.filter((a) => a.actionType === 'skip').map((a) => a.segment)
-        )
-        .catch(
-            (e) =>
-                console.log(
-                    `Sponsorblock: failed fetching skipSegments for ${videoID}, reason: ${e}`
-                ) || []
-        );
+	fetch(`https://sponsor.ajay.app/api/skipSegments?videoID=${videoID}`)
+		.then((r) => r.json())
+		.then((rJson) =>
+			rJson.filter((a) => a.actionType === 'skip').map((a) => a.segment)
+		)
+		.catch(
+			(e) =>
+				console.log(
+					`Sponsorblock: failed fetching skipSegments for ${videoID}, reason: ${e}`
+				) || []
+		);
 
 const skipSegments = async () => {
-    const videoID = new URL(document.location).searchParams.get('v');
-    if (!videoID) {
-        return;
-    }
-    const key = `segmentsToSkip-${videoID}`;
-    window[key] = window[key] || (await tryFetchSkipSegments(videoID));
-    for (const v of document.querySelectorAll('video')) {
-        if (Number.isNaN(v.duration)) continue;
-        for (const [start, end] of window[key]) {
-            if (v.currentTime < end && v.currentTime >= start) {
-                console.log(`Sponsorblock: skipped video @${v.currentTime} from ${start} to ${end}`);
-                v.currentTime = end;
-		    return
-            }
-		const timeToSponsor = (start - v.currentTime) / v.playbackRate;
-		if (v.currentTime < start && timeToSponsor < (delay/1000)) {
-			console.log(`Sponsorblock: Almost at sponsor segment, sleep for ${timeToSponsor*1000}ms`);
-			setTimeout(skipSegments, timeToSponsor * 1000);
+	const videoID = new URL(document.location).searchParams.get('v');
+	if (!videoID) {
+		return;
+	}
+	const key = `segmentsToSkip-${videoID}`;
+	window[key] = window[key] || (await tryFetchSkipSegments(videoID));
+	for (const v of document.querySelectorAll('video')) {
+		if (Number.isNaN(v.duration)) continue;
+		for (const [start, end] of window[key]) {
+			if (v.currentTime < end && v.currentTime >= start) {
+				console.log(`Sponsorblock: skipped video @${v.currentTime} from ${start} to ${end}`);
+				v.currentTime = end;
+				return
+			}
+			const timeToSponsor = (start - v.currentTime) / v.playbackRate;
+			if (v.currentTime < start && timeToSponsor < (delay / 1000)) {
+				console.log(`Sponsorblock: Almost at sponsor segment, sleep for ${timeToSponsor * 1000}ms`);
+				setTimeout(skipSegments, timeToSponsor * 1000);
+			}
 		}
-        }
-    }
+	}
 };
 if (!window.skipSegmentsIntervalID) {
-    window.skipSegmentsIntervalID = setInterval(skipSegments, delay);
+	window.skipSegmentsIntervalID = setInterval(skipSegments, delay);
 }


### PR DESCRIPTION
Detect if we are close to sponsor segment and then sleep for that exact amount of time. This even works with a playback rate other than 1.
This usually results in an accuracy of 3ms or less, aka frame-perfect sponsor skips.